### PR TITLE
Switch from http to https for the demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@
 A GDPR tracking consent popup. It asks for approval to include tracking objects (cookies, images or any HTML) and includes the objects when consented. It enables tracking from the very first page (including referrer). Consents are shown in groups and saved to a cookie. It provides a stable API to read out consents with JavaScript.
 
 ## Demo
-You can click around the 3 included demo themes in our [demo](http://cookieman.d-mind.de/). Have a look at the JavaScript console to see when tracking gets enabled. You can also try out the ["Do-not-track" setting of your browser](https://en.wikipedia.org/wiki/Do_Not_Track) which triggers a message inside the popup (in the "marketing" group) when enabled.
+You can click around the 3 included demo themes in our [demo](https://cookieman.d-mind.de/). Have a look at the JavaScript console to see when tracking gets enabled. You can also try out the ["Do-not-track" setting of your browser](https://en.wikipedia.org/wiki/Do_Not_Track) which triggers a message inside the popup (in the "marketing" group) when enabled.
 
 ## Links
 | **Features / Documentation / Manual** | <https://docs.typo3.org/p/dmind/cookieman/master/en-us/> |
 | --- | --- |
-| Demo | <http://cookieman.d-mind.de/> |
+| Demo | <https://cookieman.d-mind.de/> |
 | TYPO3 extension repository |	<https://extensions.typo3.org/extension/cookieman> |
 | CI | <https://github.com/dmind-gmbh/extension-cookieman/actions> |
 | Packagist | <https://packagist.org/packages/dmind/cookieman> |


### PR DESCRIPTION
This is necessary because http version does not work. In addition it may be of interest to implement a permanent redirect to https.

![image](https://user-images.githubusercontent.com/5464339/91644766-97de7800-ea3f-11ea-987c-446a53f00f2c.png)