### PR TITLE
[DOCS] Fix formatting problems in docs

### DIFF
--- a/Documentation/Configuration/Customization/Index.rst
+++ b/Documentation/Configuration/Customization/Index.rst
@@ -89,7 +89,7 @@ These **HTML element attributes** control the functionality:
    Mark all checkboxes
 
 <* data-cookieman-accept-none>
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
    Uncheck all checkboxes (will just leave the groups with the options preselected=1, disabled=1 checked)
 

--- a/Documentation/Configuration/Reference/Index.rst
+++ b/Documentation/Configuration/Reference/Index.rst
@@ -526,7 +526,7 @@ trackingObjects.‹tracking-object-key›.show.‹tracking-item-key›.provider
 .. _trackingObjects.‹tracking-object-key›.show.‹tracking-item-key›.htmlCookieRemovalPattern:
 
 trackingObjects.‹tracking-object-key›.show.‹tracking-item-key›.htmlCookieRemovalPattern
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :aspect:`Property`
    trackingObjects.‹tracking-object-key›.show.‹tracking-item-key›.htmlCookieRemovalPattern

--- a/Documentation/Contributors/Index.rst
+++ b/Documentation/Contributors/Index.rst
@@ -2,6 +2,7 @@
 
 
 .. _contributing:
+.. _contributors:
 
 ============
 Contributing
@@ -51,7 +52,8 @@ After switching branches, you might need a `git clean -fdX` to remove any ignore
 created by another version's build (append `-e '!.idea'` to exclude .idea).
 
 Supported TYPO3 versions
-~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
+
 * all LTS versions: features, bugfixes, security
 * ELTS versions: security
 

--- a/Documentation/Contributors/Index.rst
+++ b/Documentation/Contributors/Index.rst
@@ -2,6 +2,8 @@
 
 
 .. _contributing:
+
+.. Helps Github discover the contributors page:
 .. _contributors:
 
 ============

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -31,7 +31,7 @@ Installation
 
    **Pay attention to the extension's version number!**
 
-   Each version of Cookieman **only supports a single LTS version of TYPO3** (TYPO3 v8-*).
+   Each version of Cookieman **only supports a single LTS version of TYPO3** (TYPO3 `v8-*`).
    This might be a bit confusing but makes development and testing easier.
 
 #. **Get the extension:**


### PR DESCRIPTION
In reStructuredTexts lists must have a previous and following newline.
Otherwise this may not get rendered correctly.

Underlines should always be at least as long as the section header text.

----

The following is not part of the commit message:

Example how the list is rendering with missing newlines (starting with "Supported TYPO3 versions"):

![image](https://user-images.githubusercontent.com/13206455/133754063-ee82e808-197f-4dfc-ac89-af4c1e8ab8d7.png)


**Additional tips:**

* see common pitfalls for reStructuredText: https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/WritingReST/BasicRestSyntax.html
* if you have CONTRIBUTING.rst / CONTRIBUTING.md, this will automatically be shown on GitHub (e.g. if you click on the Issues section). This is a tradeoff - either the contributing info is shown on GitHub or you have it nicely rendered withing the docs, but you can use a combination: Hava a placeholder CONTRIBUTING.rst and in that link to the contribution section in the docs.
* The rendering errrors are shown in warnings.txt:

[run the rendering locally](https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/RenderingDocs/Index.html) will show you the path to warnings.txt:

```
Find the results:
  ./Documentation-GENERATED-temp/Result/project/0.0.0/Index.html
  ./Documentation-GENERATED-temp/Result/project/0.0.0/_buildinfo
  ./Documentation-GENERATED-temp/Result/project/0.0.0/_buildinfo/warnings.txt

```

cat Documentation-GENERATED-temp/Result/project/0.0.0/_buildinfo/warnings.txt
```
..
/Documentation/Configuration/Customization/Index.rst:92: WARNING: Title underline too short.

<* data-cookieman-accept-none>
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
./Documentation/Configuration/Customization/Index.rst:92: WARNING: Title underline too short.
..
```

* Alternatively, you can also add GitHub actions for rendering docs, as done in the official documentation.

Btw, kudos for having an "Edit on GitHub" button and information for contributors. Not many extension authors do this.