### PR TITLE
Css mask not working on Chrome (Webkit)

### DIFF
--- a/Resources/Public/Themes/bootstrap5-modal/cookieman-theme.css
+++ b/Resources/Public/Themes/bootstrap5-modal/cookieman-theme.css
@@ -11,6 +11,7 @@
   content: '';
   /* mask-image allows to use the background-color */
   mask-image: url("data:image/svg+xml,<svg viewBox='0 0 16 16' fill='currentColor' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z' clip-rule='evenodd'/></svg>");
+  -webkit-mask-image: url("data:image/svg+xml,<svg viewBox='0 0 16 16' fill='currentColor' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z' clip-rule='evenodd'/></svg>");  
   background-color: white;
   background-size: 1.25em;
   background-repeat: no-repeat;


### PR DESCRIPTION
The -webkit-mask-image is a solution according to this: https://stackoverflow.com/questions/44100139/css-mask-not-working-on-chrome-webkit

Testet in Brave Browser (Version 1.37.111 Chromium: 100.0.4896.79) and Chromium (v85.0.4154.0)