### PR TITLE
[BUGFIX] Avoid JS error if unminified versions are used

### DIFF
--- a/Resources/Public/Js/cookieman.js
+++ b/Resources/Public/Js/cookieman.js
@@ -468,4 +468,4 @@ var cookieman = (function () {
          */
         eventsEl: eventsEl
     }
-}())
+}());


### PR DESCRIPTION
Setting plugin.tx_cookieman.settings.minify=0 causes JS error:
Uncaught TypeError: (intermediate value)(intermediate value)(intermediate value)(intermediate value)(...) is not a function