### PR TITLE
accessibility: table heading scopes added

### DIFF
--- a/Resources/Private/Themes/bootstrap3-banner/Templates/Popup.html
+++ b/Resources/Private/Themes/bootstrap3-banner/Templates/Popup.html
@@ -79,11 +79,11 @@
                                                     <table class="table table-hover table-condensed">
                                                         <thead>
                                                         <tr>
-                                                            <th>{f:translate(key: 'tableheader.name', extensionName: 'cookieman')}</th>
-                                                            <th>{f:translate(key: 'tableheader.purpose', extensionName: 'cookieman')}</th>
-                                                            <th>{f:translate(key: 'tableheader.duration', extensionName: 'cookieman')}</th>
-                                                            <th>{f:translate(key: 'tableheader.type', extensionName: 'cookieman')}</th>
-                                                            <th>{f:translate(key: 'tableheader.provider', extensionName: 'cookieman')}</th>
+                                                            <th scope="col">{f:translate(key: 'tableheader.name', extensionName: 'cookieman')}</th>
+                                                            <th scope="col">{f:translate(key: 'tableheader.purpose', extensionName: 'cookieman')}</th>
+                                                            <th scope="col">{f:translate(key: 'tableheader.duration', extensionName: 'cookieman')}</th>
+                                                            <th scope="col">{f:translate(key: 'tableheader.type', extensionName: 'cookieman')}</th>
+                                                            <th scope="col">{f:translate(key: 'tableheader.provider', extensionName: 'cookieman')}</th>
                                                         </tr>
                                                         </thead>
                                                         <tbody>

--- a/Resources/Private/Themes/bootstrap3-modal/Templates/Popup.html
+++ b/Resources/Private/Themes/bootstrap3-modal/Templates/Popup.html
@@ -71,11 +71,11 @@
                                                     <table class="table table-hover table-condensed">
                                                         <thead>
                                                         <tr>
-                                                            <th>{f:translate(key: 'tableheader.name', extensionName: 'cookieman')}</th>
-                                                            <th>{f:translate(key: 'tableheader.purpose', extensionName: 'cookieman')}</th>
-                                                            <th>{f:translate(key: 'tableheader.duration', extensionName: 'cookieman')}</th>
-                                                            <th>{f:translate(key: 'tableheader.type', extensionName: 'cookieman')}</th>
-                                                            <th>{f:translate(key: 'tableheader.provider', extensionName: 'cookieman')}</th>
+                                                            <th scope="col">{f:translate(key: 'tableheader.name', extensionName: 'cookieman')}</th>
+                                                            <th scope="col">{f:translate(key: 'tableheader.purpose', extensionName: 'cookieman')}</th>
+                                                            <th scope="col">{f:translate(key: 'tableheader.duration', extensionName: 'cookieman')}</th>
+                                                            <th scope="col">{f:translate(key: 'tableheader.type', extensionName: 'cookieman')}</th>
+                                                            <th scope="col">{f:translate(key: 'tableheader.provider', extensionName: 'cookieman')}</th>
                                                         </tr>
                                                         </thead>
                                                         <tbody>

--- a/Resources/Private/Themes/bootstrap4-modal/Templates/Popup.html
+++ b/Resources/Private/Themes/bootstrap4-modal/Templates/Popup.html
@@ -66,11 +66,11 @@
                                                 <table class="table table-hover table-sm">
                                                     <thead>
                                                     <tr>
-                                                        <th>{f:translate(key: 'tableheader.name', extensionName: 'cookieman')}</th>
-                                                        <th>{f:translate(key: 'tableheader.purpose', extensionName: 'cookieman')}</th>
-                                                        <th>{f:translate(key: 'tableheader.duration', extensionName: 'cookieman')}</th>
-                                                        <th>{f:translate(key: 'tableheader.type', extensionName: 'cookieman')}</th>
-                                                        <th>{f:translate(key: 'tableheader.provider', extensionName: 'cookieman')}</th>
+                                                        <th scope="col">{f:translate(key: 'tableheader.name', extensionName: 'cookieman')}</th>
+                                                        <th scope="col">{f:translate(key: 'tableheader.purpose', extensionName: 'cookieman')}</th>
+                                                        <th scope="col">{f:translate(key: 'tableheader.duration', extensionName: 'cookieman')}</th>
+                                                        <th scope="col">{f:translate(key: 'tableheader.type', extensionName: 'cookieman')}</th>
+                                                        <th scope="col">{f:translate(key: 'tableheader.provider', extensionName: 'cookieman')}</th>
                                                     </tr>
                                                     </thead>
                                                     <tbody>

--- a/Resources/Private/Themes/bootstrap5-modal/Templates/Popup.html
+++ b/Resources/Private/Themes/bootstrap5-modal/Templates/Popup.html
@@ -72,11 +72,11 @@
                                                 <table class="table table-hover table-sm">
                                                     <thead>
                                                     <tr>
-                                                        <th>{f:translate(key: 'tableheader.name', extensionName: 'cookieman')}</th>
-                                                        <th>{f:translate(key: 'tableheader.purpose', extensionName: 'cookieman')}</th>
-                                                        <th>{f:translate(key: 'tableheader.duration', extensionName: 'cookieman')}</th>
-                                                        <th>{f:translate(key: 'tableheader.type', extensionName: 'cookieman')}</th>
-                                                        <th>{f:translate(key: 'tableheader.provider', extensionName: 'cookieman')}</th>
+                                                        <th scope="col">{f:translate(key: 'tableheader.name', extensionName: 'cookieman')}</th>
+                                                        <th scope="col">{f:translate(key: 'tableheader.purpose', extensionName: 'cookieman')}</th>
+                                                        <th scope="col">{f:translate(key: 'tableheader.duration', extensionName: 'cookieman')}</th>
+                                                        <th scope="col">{f:translate(key: 'tableheader.type', extensionName: 'cookieman')}</th>
+                                                        <th scope="col">{f:translate(key: 'tableheader.provider', extensionName: 'cookieman')}</th>
                                                     </tr>
                                                     </thead>
                                                     <tbody>


### PR DESCRIPTION
All table headers should define a valid scope attribute, which tells assistive technologies what the header refers to (from addOn Silktide).